### PR TITLE
bump version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .pyc
 *.pyc
+arcpylogger.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='arcpylogger',
-    version='1.0.0',
+    version='2.0.0',
     packages=['arcpylogger'],
     url='https://github.com/gisinc/ArcPyLogger',
     license='MIT',


### PR DESCRIPTION
bumping major because 64bacf814ce208565 is potentially a breaking change (i.e., it can break users who haven't yet switched to using `.pyt` toolboxes)
